### PR TITLE
Добавлен кодер Хэмминга с матрицей G и тестами для (7,4) и (15,11)

### DIFF
--- a/cmake/Project.cmake
+++ b/cmake/Project.cmake
@@ -6,6 +6,7 @@ add_library(harq STATIC
     ${CMAKE_CURRENT_LIST_DIR}/../src/bpsk.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../src/bpsk_passband.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../src/chase_algorithm.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/../src/hamming_encoder.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../src/utils.cpp
 )
 

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -13,6 +13,7 @@ if(BUILD_TESTING)
         ${CMAKE_CURRENT_LIST_DIR}/../tests/bpsk_test.cpp
         ${CMAKE_CURRENT_LIST_DIR}/../tests/bpsk_passband_test.cpp
         ${CMAKE_CURRENT_LIST_DIR}/../tests/chase_algorithm_test.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/../tests/hamming_encoder_test.cpp
     )
 
     target_link_libraries(bpsk_tests

--- a/include/hamming_encoder.hpp
+++ b/include/hamming_encoder.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace harq {
+
+// Модуль кодера Хэмминга: строит коды (2^r - 1, 2^r - 1 - r) и матрицу G.
+// Позиции паритетов находятся на степенях двойки, нумерация битов начинается с 1.
+class HammingEncoder {
+ public:
+  explicit HammingEncoder(int r);
+
+  int n() const;
+  int k() const;
+
+  const std::vector<std::vector<uint8_t>>& generator_matrix() const;
+
+  // Кодирует k битов данных в n-битовое кодовое слово Хэмминга через матрицу G.
+  std::vector<uint8_t> Encode(const std::vector<uint8_t>& data) const;
+
+ private:
+  static bool IsPowerOfTwo(int value);
+  std::vector<uint8_t> BuildCodewordFromData(
+      const std::vector<uint8_t>& data) const;
+
+  int r_;
+  int n_;
+  int k_;
+  std::vector<int> parity_positions_;
+  std::vector<int> data_positions_;
+  std::vector<std::vector<uint8_t>> generator_;
+};
+
+}  // namespace harq

--- a/src/hamming_encoder.cpp
+++ b/src/hamming_encoder.cpp
@@ -1,0 +1,105 @@
+#include "hamming_encoder.hpp"
+
+#include <stdexcept>
+
+namespace harq {
+
+HammingEncoder::HammingEncoder(int r) : r_(r), n_(0), k_(0) {
+  if (r_ < 2) {
+    throw std::invalid_argument("Hamming encoder expects r >= 2.");
+  }
+
+  n_ = (1 << r_) - 1;
+  k_ = n_ - r_;
+
+  parity_positions_.reserve(r_);
+  for (int i = 0; i < r_; i++) {
+    parity_positions_.push_back(1 << i);
+  }
+
+  for (int pos = 1; pos <= n_; pos++) {
+    if (!IsPowerOfTwo(pos)) {
+      data_positions_.push_back(pos);
+    }
+  }
+
+  // Строим матрицу G, кодируя единичные векторы.
+  generator_.resize(k_, std::vector<uint8_t>(n_, 0));
+  for (int i = 0; i < k_; i++) {
+    std::vector<uint8_t> basis(k_, 0);
+    basis[i] = 1;
+    generator_[i] = BuildCodewordFromData(basis);
+  }
+}
+
+int HammingEncoder::n() const { return n_; }
+
+int HammingEncoder::k() const { return k_; }
+
+const std::vector<std::vector<uint8_t>>&
+HammingEncoder::generator_matrix() const {
+  return generator_;
+}
+
+std::vector<uint8_t> HammingEncoder::Encode(
+    const std::vector<uint8_t>& data) const {
+  if (static_cast<int>(data.size()) != k_) {
+    throw std::invalid_argument("Hamming encoder expects k data bits.");
+  }
+
+  std::vector<uint8_t> codeword(n_, 0);
+  // Перемножение сообщения с матрицей G над GF(2).
+  for (int i = 0; i < k_; i++) {
+    uint8_t bit = data[i];
+    if (bit != 0 && bit != 1) {
+      throw std::invalid_argument("Hamming encoder expects bits 0 or 1.");
+    }
+    if (bit == 1) {
+      for (int j = 0; j < n_; j++) {
+        codeword[j] ^= generator_[i][j];
+      }
+    }
+  }
+
+  return codeword;
+}
+
+bool HammingEncoder::IsPowerOfTwo(int value) {
+  return value > 0 && (value & (value - 1)) == 0;
+}
+
+std::vector<uint8_t> HammingEncoder::BuildCodewordFromData(
+    const std::vector<uint8_t>& data) const {
+  if (static_cast<int>(data.size()) != k_) {
+    throw std::invalid_argument("Hamming encoder expects k data bits.");
+  }
+
+  std::vector<uint8_t> codeword(n_, 0);
+  // Раскладываем данные по позициям, не являющимся паритетными.
+  for (size_t i = 0; i < data_positions_.size(); i++) {
+    uint8_t bit = data[i];
+    if (bit != 0 && bit != 1) {
+      throw std::invalid_argument("Hamming encoder expects bits 0 or 1.");
+    }
+    int pos = data_positions_[i];
+    codeword[pos - 1] = bit;
+  }
+
+  // Считаем паритет как XOR по позициям с соответствующим установленным битом маски.
+  for (int parity_pos : parity_positions_) {
+    uint8_t parity = 0;
+    for (int pos = 1; pos <= n_; pos++) {
+      if (pos == parity_pos) {
+        continue;
+      }
+      if ((pos & parity_pos) != 0) {
+        parity ^= codeword[pos - 1];
+      }
+    }
+    codeword[parity_pos - 1] = parity;
+  }
+
+  return codeword;
+}
+
+}  // namespace harq

--- a/tests/hamming_encoder_test.cpp
+++ b/tests/hamming_encoder_test.cpp
@@ -1,0 +1,81 @@
+#include "hamming_encoder.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+std::vector<std::vector<uint8_t>> BuildParityCheckMatrix(int r) {
+  int n = (1 << r) - 1;
+  std::vector<std::vector<uint8_t>> matrix(
+      r, std::vector<uint8_t>(n, 0));
+
+  // Столбцы — двоичные индексы 1..n (младший бит в строке 0).
+  for (int col = 1; col <= n; col++) {
+    for (int row = 0; row < r; row++) {
+      matrix[row][col - 1] = static_cast<uint8_t>((col >> row) & 1);
+    }
+  }
+
+  return matrix;
+}
+
+std::vector<uint8_t> ComputeSyndrome(
+    const std::vector<std::vector<uint8_t>>& matrix,
+    const std::vector<uint8_t>& codeword) {
+  std::vector<uint8_t> syndrome(matrix.size(), 0);
+  // s = H * c^T над GF(2).
+  for (size_t row = 0; row < matrix.size(); row++) {
+    uint8_t value = 0;
+    for (size_t col = 0; col < codeword.size(); col++) {
+      value ^= static_cast<uint8_t>(matrix[row][col] & codeword[col]);
+    }
+    syndrome[row] = value;
+  }
+  return syndrome;
+}
+
+}  // namespace
+
+TEST(HammingEncoderTest, GeneratorMatrixSize) {
+  harq::HammingEncoder encoder(3);
+  const auto& matrix = encoder.generator_matrix();
+
+  ASSERT_EQ(matrix.size(), 4u);
+  for (const auto& row : matrix) {
+    EXPECT_EQ(row.size(), 7u);
+  }
+}
+
+TEST(HammingEncoderTest, EncodesKnownMessage74) {
+  harq::HammingEncoder encoder(3);
+  const std::vector<uint8_t> message = {1, 0, 1, 1};
+  const std::vector<uint8_t> expected = {0, 1, 1, 0, 0, 1, 1};
+
+  const std::vector<uint8_t> codeword = encoder.Encode(message);
+
+  EXPECT_EQ(codeword, expected);
+}
+
+TEST(HammingEncoderTest, EncodedCodewordHasZeroSyndrome1511) {
+  harq::HammingEncoder encoder(4);
+  const std::vector<uint8_t> message = {1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1};
+  const std::vector<uint8_t> codeword = encoder.Encode(message);
+
+  const auto parity_check = BuildParityCheckMatrix(4);
+  const std::vector<uint8_t> syndrome =
+      ComputeSyndrome(parity_check, codeword);
+
+  EXPECT_EQ(syndrome, std::vector<uint8_t>({0, 0, 0, 0}));
+}
+
+TEST(HammingEncoderTest, ThrowsOnInvalidInput) {
+  EXPECT_THROW(harq::HammingEncoder(1), std::invalid_argument);
+
+  harq::HammingEncoder encoder(3);
+  EXPECT_THROW(encoder.Encode({1, 0}), std::invalid_argument);
+  EXPECT_THROW(encoder.Encode({0, 1, 2, 0}), std::invalid_argument);
+}


### PR DESCRIPTION
## Задача
  Реализовать кодер Хэмминга через матрицу G для кодов вида `(2^r - 1, 2^r - 1 - r)`, добавить тесты для `(7,4)` и `(15,11)` без канала.

  ## Что сделано
  - Добавлен модуль `HammingEncoder`, который строит матрицу G и кодирует сообщение по модулю 2.
  - Реализована генерация кодового слова с паритетами на позициях степеней двойки (нумерация с 1).
  - Добавлены тесты на размер матрицы G, корректное кодовое слово для `(7,4)` и нулевой синдром для `(15,11)`.
  - Подключены новые исходники и тесты в CMake.